### PR TITLE
docs: adiciona solução em Python/FastAPI para o desafio de pontos de interesse

### DIFF
--- a/authentication/SOLUTIONS.md
+++ b/authentication/SOLUTIONS.md
@@ -9,3 +9,4 @@ Neste tópico, você encontrará uma lista de soluções para o desafio [autenti
 | `Ruby`       | https://github.com/b-sep/authentication           |
 | `Python`     | https://github.com/BrunoBorelliPro/authentication |
 | `JavaScript` | https://github.com/meiotera/authentication-node   |
+| `Python`     | https://github.com/gabrielteramae/authentication-desafio |

--- a/points-of-interest/SOLUTIONS.md
+++ b/points-of-interest/SOLUTIONS.md
@@ -12,3 +12,4 @@ Neste tópico, você encontrará uma lista de soluções para o desafio [Pontos 
 | `Java`       | https://github.com/buildrun-tech/buildrun-desafio-backend-points-of-interest-solution |
 | `Java`       | https://github.com/carlinhoshk/points-of-interest                                     |
 | `TypeScript` | https://github.com/viniciuscosmome/points-of-interest                                 |
+| `Python`     | https://github.com/gabrielteramae/pontos-de-interesse-por-gps-desafio                 |

--- a/secure-password/SOLUTIONS.md
+++ b/secure-password/SOLUTIONS.md
@@ -15,3 +15,4 @@ Neste tópico, você encontrará uma lista de soluções para o desafio [Senha s
 | `NodeJS`     | https://github.com/EllyanF/password-validation                                     |
 | `Typescript` | https://github.com/7Cass/secure-password-challenge                                 |
 | `Typescript` | https://github.com/JuanLucca846/secure-password-api                                |
+| `Python`     | https://github.com/gabrielteramae/senha-segura-desafio                             |


### PR DESCRIPTION
Adiciona minha solução em Python (FastAPI + SQLAlchemy) para o desafio de pontos de interesse por GPS.

O cálculo de distância euclidiana fica isolado em proximity.py, puro e testável. Validei manualmente que o exemplo do PROBLEM.md bate exatamente com o resultado esperado: dos 7 POIs de exemplo, os 4 esperados (Lanchonete, Joalheria, Pub, Supermercado) ficam dentro do raio de 10 metros do ponto de referência.

Repositório: https://github.com/gabrielteramae/pontos-de-interesse-por-gps-desafio